### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   RUST_VERSION: 1.90.0
   SOROBAN_CLI_VERSION: 22.8.1


### PR DESCRIPTION
Potential fix for [https://github.com/ContangoBR/contract/security/code-scanning/3](https://github.com/ContangoBR/contract/security/code-scanning/3)

To fix this, explicitly restrict `GITHUB_TOKEN` permissions in the workflow YAML. Since both jobs (`test-and-build` and `security-audit`) only check out code, cache dependencies, run `cargo` commands, and upload artifacts, they only need read access to repository contents. GitHub’s minimal starting point for most CI is `permissions: contents: read`. Adding this at the workflow root will apply to all jobs that don’t override it.

The best fix with minimal behavior change is:
- Add a `permissions:` block at the top level (same indentation as `on:` and `env:`) specifying `contents: read`.
- This ensures both existing jobs only have read access to repo contents, while still allowing `actions/checkout` to function and not affecting any other functionality.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert, after the `on:` block (lines 3–7) and before `env:` (line 9), a new root-level block:
  ```yaml
  permissions:
    contents: read
  ```
No imports or additional methods are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
