### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.90.0


### PR DESCRIPTION
Potential fix for [https://github.com/ContangoBR/contract/security/code-scanning/1](https://github.com/ContangoBR/contract/security/code-scanning/1)

General fix: Add an explicit `permissions:` block that grants only the minimal necessary scopes for this workflow. Since this job only needs to read the repository contents and does not interact with issues/PRs/releases, the minimal and appropriate scope is `contents: read`. Defining this at the workflow root will apply to all jobs unless overridden.

Best concrete fix: Edit `.github/workflows/coverage.yml` and add a `permissions:` section near the top (after `name:` or after `on:`). For clarity and convention, place it after the `on:` block so it clearly applies to the whole workflow:

```yaml
permissions:
  contents: read
```

No other changes are required because none of the steps need additional GitHub write permissions. The external services (Codecov, cache, artifacts) use the `GITHUB_TOKEN` only within the bounds of `contents: read` or their own mechanisms. This preserves existing functionality while constraining the token.

Specific location: Insert the `permissions` mapping between lines 7 and 9 (i.e., after the `on:` block and before `env:`) in `.github/workflows/coverage.yml`.

No imports, methods, or additional definitions are needed; it is a pure YAML configuration change inside the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
